### PR TITLE
Revert "tests/: Don't run Lomiri related unit test, if library hasn't been bu…"

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,5 @@
 find_package(GMock)
 
-if(URLDISPATCHER_FOUND)
-    add_definitions( -DHAS_URLDISPATCHER )
-endif()
-
 include_directories(
     ${CMAKE_SOURCE_DIR}/src
 )

--- a/tests/tst_utils.cpp
+++ b/tests/tst_utils.cpp
@@ -35,14 +35,12 @@ public:
    }
 };
 
-#ifdef HAS_URLDISPATCHER
 TEST_F(XdgCurrentDesktopUtilsTest, isLomiri)
 {
     EXPECT_FALSE(is_lomiri());
     setenv("XDG_CURRENT_DESKTOP", "Lomiri", 1);
     EXPECT_TRUE(is_lomiri());
 }
-#endif
 
 TEST_F(XdgCurrentDesktopUtilsTest, isGnome)
 {


### PR DESCRIPTION
Reverts AyatanaIndicators/libayatana-common#1

This has nothing to do with url-dispatcher, libayatana should be able to detect and test the destkop environment regardless if url-dispatcher is there. 