### PR TITLE
debian/control: Add zenity dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Package: libayatana-common0
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+         zenity | lomiri,
 Multi-Arch: same
 Description: Ayatana System Indicators' common API functions (shared library)
  This package contains common API functions used by Ayatana System


### PR DESCRIPTION
@sunweaver:

Please modify this to make it Lomiri-friendly. My expertise ends here. We will also need it released to be able to depend indicators on 0.9.9. All clear for release on the Arch side.